### PR TITLE
python_datasource: add syntactic sugar

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -33,7 +33,8 @@ geometry with an appropriate level of detail for the output resolution.
 ## Initialization
 
 Only the `factory` parameter is required. This is of the form
-`[module:]callable`. If `module` is present then `module` will be imported and
+`[module:]callable` or `[module.]callable`.
+If `module` is present then `module` will be imported and
 its attribute named `callable` will be used as a factory callable. If `module`
 is omitted, then `__main__` is used. Any other parameter aside from `factory` or
 `type` will be passed directly to the callable as keyword arguments. Note that

--- a/python/python_datasource.cpp
+++ b/python/python_datasource.cpp
@@ -50,11 +50,11 @@ python_datasource::python_datasource(parameters const& params)
     {
         // split factory at ':' to parse out module and callable
         std::vector<std::string> factory_split;
-        split(factory_split, factory_, is_any_of(":"));
+        split(factory_split, factory_, is_any_of(":."));
         if ((factory_split.size() < 1) || (factory_split.size() > 2))
         {
             throw mapnik::datasource_exception(
-                std::string("python: factory string must be of the form '[module:]callable' when parsing \"")
+                std::string("python: factory string must be of the form '[module:]callable' or '[module.]callable' when parsing \"")
                       + factory_ + '"');
         }
         // extract the module and the callable


### PR DESCRIPTION
Python devs are used to using '.' as a separator between modulename and
callable, and ':' is not Pythonic (although it certainly makes sense
from a C++ point of view. Let's allow both.

closes #1
